### PR TITLE
OSPC-696: Added the changes for the default_domain configuration

### DIFF
--- a/doc/source/configuration/settings.rst
+++ b/doc/source/configuration/settings.rst
@@ -73,7 +73,7 @@ file ``skyline.yaml.sample`` in ``etc`` directory.
       system_user_domain: Default
       system_user_name: skyline
       system_user_password: ''
-      user_default_domain: Default
+      default_domain: Default
     setting:
       base_settings:
       - flavor_families

--- a/doc/source/configuration/settings.rst
+++ b/doc/source/configuration/settings.rst
@@ -73,6 +73,7 @@ file ``skyline.yaml.sample`` in ``etc`` directory.
       system_user_domain: Default
       system_user_name: skyline
       system_user_password: ''
+      user_default_domain: Default
     setting:
       base_settings:
       - flavor_families

--- a/etc/skyline.yaml.sample
+++ b/etc/skyline.yaml.sample
@@ -62,7 +62,7 @@ openstack:
   system_user_domain: Default
   system_user_name: skyline
   system_user_password: ''
-  user_default_domain: Default
+  default_domain: Default
 setting:
   base_settings:
   - flavor_families

--- a/etc/skyline.yaml.sample
+++ b/etc/skyline.yaml.sample
@@ -62,6 +62,7 @@ openstack:
   system_user_domain: Default
   system_user_name: skyline
   system_user_password: ''
+  user_default_domain: Default
 setting:
   base_settings:
   - flavor_families

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -174,10 +174,11 @@ async def login(
     ),
 ) -> schemas.Profile:
     region = credential.region or CONF.openstack.default_region
+    domain=credential.domain or CONF.openstack.user_default_domain
     try:
         project_scope, unscope_token, default_project_id = await _get_projects_and_unscope_token(
             region=region,
-            domain=credential.domain,
+            domain=domain,
             username=credential.username,
             password=credential.password,
             project_enabled=True,
@@ -207,6 +208,14 @@ async def login(
         response.set_cookie(constants.TIME_EXPIRED_KEY, str(profile.exp))
         return profile
 
+@router.get("/config", response_model=Dict[str,str])
+async def get_domain_config() -> Dict[str,str]:
+    """
+    returns user default domain to skyline console
+    """
+    return {
+            "user_default_domain": CONF.openstack.user_default_domain,
+    }
 
 @router.get(
     "/sso",

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -68,18 +68,20 @@ async def _get_projects_and_unscope_token(
     token: Optional[str] = None,
     project_enabled: bool = False,
 ) -> Tuple[List[Any], str, Union[str, None]]:
+    LOG.info('Getting the auth url')
     auth_url = await utils.get_endpoint(
         region=region,
         service="identity",
         session=get_system_session(),
     )
-
+    LOG.info('Getting the token inside _get_projects_and_unscope_token')
     if token:
         unscope_auth = Token(
             auth_url=auth_url,
             token=token,
             reauthenticate=False,
         )
+    LOG.info('After getting the Token')
     else:
         unscope_auth = Password(
             auth_url=auth_url,
@@ -88,11 +90,11 @@ async def _get_projects_and_unscope_token(
             password=password,
             reauthenticate=False,
         )
-
+    LOG.info('After else of unscope_auth = Password')
     session = Session(
         auth=unscope_auth, verify=CONF.default.cafile, timeout=constants.DEFAULT_TIMEOUT
     )
-
+    LOG.info('After creating session')
     unscope_client = KeystoneClient(
         session=session,
         endpoint=auth_url,
@@ -104,12 +106,12 @@ async def _get_projects_and_unscope_token(
 
     if project_enabled:
         project_scope = [scope for scope in project_scope if scope.enabled]
-
+    LOG.inf('After the project_enabled checks')
     if not project_scope:
         raise Exception("You are not authorized for any projects or domains.")
 
     default_project_id = await _get_default_project_id(session, region)
-
+    LOG.info('Before returning from get_projects_and_unscope_token')
     return project_scope, unscope_token, default_project_id
 
 
@@ -174,7 +176,9 @@ async def login(
     ),
 ) -> schemas.Profile:
     region = credential.region or CONF.openstack.default_region
+    LOG.info('credential.domain is: ',credential.domain)
     domain=credential.domain or CONF.openstack.default_domain
+    LOG.info('domain is: ',domain)
     try:
         LOG.info('Fetching project_scope, unscope_token, default_project_id')
         project_scope, unscope_token, default_project_id = await _get_projects_and_unscope_token(

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -73,6 +73,7 @@ async def _get_projects_and_unscope_token(
         service="identity",
         session=get_system_session(),
     )
+
     if token:
         unscope_auth = Token(
             auth_url=auth_url,
@@ -87,9 +88,11 @@ async def _get_projects_and_unscope_token(
             password=password,
             reauthenticate=False,
         )
+
     session = Session(
         auth=unscope_auth, verify=CONF.default.cafile, timeout=constants.DEFAULT_TIMEOUT
     )
+
     unscope_client = KeystoneClient(
         session=session,
         endpoint=auth_url,
@@ -101,10 +104,12 @@ async def _get_projects_and_unscope_token(
 
     if project_enabled:
         project_scope = [scope for scope in project_scope if scope.enabled]
+
     if not project_scope:
         raise Exception("You are not authorized for any projects or domains.")
 
     default_project_id = await _get_default_project_id(session, region)
+
     return project_scope, unscope_token, default_project_id
 
 
@@ -186,10 +191,12 @@ async def login(
             region=region,
             project_id=default_project_id or project_scope[0].id,
         )
+
         profile = await generate_profile(
             keystone_token=project_scope_token,
             region=region,
         )
+
         profile = await _patch_profile(profile, x_openstack_request_id)
     except Exception as e:
         raise HTTPException(

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -223,7 +223,7 @@ async def get_domain_config(request: Request) -> UserDefaultDomain:
 
 @router.get(
     "/sso",
-    description="SSO configuration.",
+    description="SSO configuration Test.",
     responses={
         200: {"model": schemas.SSO},
     },

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -81,7 +81,7 @@ async def _get_projects_and_unscope_token(
             token=token,
             reauthenticate=False,
         )
-    LOG.info('After getting the Token')
+        LOG.info('After getting the Token')
     else:
         unscope_auth = Password(
             auth_url=auth_url,

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -212,14 +212,14 @@ async def login(
         "/config",
         description="User default Domain",
         responses={
-            200: {"model": UserDefaultDomain},
+            200: {"model": schemas.UserDefaultDomain},
         },
-        response_model=UserDefaultDomain,
+        response_model=schemas.UserDefaultDomain,
         status_code=status.HTTP_200_OK,
         response_description="OK",
 )
-async def get_domain_config(request: Request) -> UserDefaultDomain:
-    return UserDefaultDomain(user_default_domain=CONF.openstack.user_default_domain)
+async def get_domain_config(request: Request) -> schemas.UserDefaultDomain:
+    return schemas.UserDefaultDomain(user_default_domain=CONF.openstack.user_default_domain)
 
 @router.get(
     "/sso",

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -106,7 +106,7 @@ async def _get_projects_and_unscope_token(
 
     if project_enabled:
         project_scope = [scope for scope in project_scope if scope.enabled]
-    LOG.inf('After the project_enabled checks')
+    LOG.info('After the project_enabled checks')
     if not project_scope:
         raise Exception("You are not authorized for any projects or domains.")
 
@@ -176,9 +176,9 @@ async def login(
     ),
 ) -> schemas.Profile:
     region = credential.region or CONF.openstack.default_region
-    LOG.info('credential.domain is: ',credential.domain)
+    LOG.info(f'credential.domain is: {credential.domain}')
     domain=credential.domain or CONF.openstack.default_domain
-    LOG.info('domain is: ',domain)
+    LOG.info(f'domain is: {domain}')
     try:
         LOG.info('Fetching project_scope, unscope_token, default_project_id')
         project_scope, unscope_token, default_project_id = await _get_projects_and_unscope_token(

--- a/skyline_apiserver/api/v1/login.py
+++ b/skyline_apiserver/api/v1/login.py
@@ -208,14 +208,18 @@ async def login(
         response.set_cookie(constants.TIME_EXPIRED_KEY, str(profile.exp))
         return profile
 
-@router.get("/config", response_model=Dict[str,str])
-async def get_domain_config() -> Dict[str,str]:
-    """
-    returns user default domain to skyline console
-    """
-    return {
-            "user_default_domain": CONF.openstack.user_default_domain,
-    }
+@router.get(
+        "/config",
+        description="User default Domain",
+        responses={
+            200: {"model": UserDefaultDomain},
+        },
+        response_model=UserDefaultDomain,
+        status_code=status.HTTP_200_OK,
+        response_description="OK",
+)
+async def get_domain_config(request: Request) -> UserDefaultDomain:
+    return UserDefaultDomain(user_default_domain=CONF.openstack.user_default_domain)
 
 @router.get(
     "/sso",

--- a/skyline_apiserver/config/openstack.py
+++ b/skyline_apiserver/config/openstack.py
@@ -192,8 +192,8 @@ sso_region = Opt(
     default="RegionOne",
 )
 
-user_default_domain = Opt(
-    name="user_default_domain",
+default_domain = Opt(
+    name="default_domain",
     description="skyline user's default domain",
     schema=StrictStr,
     default="Default",
@@ -220,7 +220,7 @@ ALL_OPTS = (
     service_mapping,
     extension_mapping,
     reclaim_instance_interval,
-    user_default_domain,
+    default_domain,
 )
 
 __all__ = ("GROUP_NAME", "ALL_OPTS")

--- a/skyline_apiserver/config/openstack.py
+++ b/skyline_apiserver/config/openstack.py
@@ -192,6 +192,13 @@ sso_region = Opt(
     default="RegionOne",
 )
 
+user_default_domain = Opt(
+    name="user_default_domain",
+    description="skyline user's default domain",
+    schema=StrictStr,
+    default="Default",
+)
+
 GROUP_NAME = __name__.split(".")[-1]
 ALL_OPTS = (
     enforce_new_defaults,
@@ -213,6 +220,7 @@ ALL_OPTS = (
     service_mapping,
     extension_mapping,
     reclaim_instance_interval,
+    user_default_domain,
 )
 
 __all__ = ("GROUP_NAME", "ALL_OPTS")

--- a/skyline_apiserver/schemas/__init__.py
+++ b/skyline_apiserver/schemas/__init__.py
@@ -42,7 +42,7 @@ from .extension import (
     VolumesResponse,
     VolumeStatus,
 )
-from .login import SSO, Credential, Payload, Profile
+from .login import SSO, Credential, Payload, Profile, UserDefaultDomain
 from .policy import Policies, PoliciesRules
 from .policy_manager import Operation, OperationsSchema, ScopeTypesSchema
 from .prometheus import (

--- a/skyline_apiserver/schemas/login.py
+++ b/skyline_apiserver/schemas/login.py
@@ -119,4 +119,4 @@ class SSO(BaseModel):
     protocols: List[SSOInfo]
 
 class UserDefaultDomain(BaseModel):
-    user_default_domain: str
+    default_domain: str

--- a/skyline_apiserver/schemas/login.py
+++ b/skyline_apiserver/schemas/login.py
@@ -117,3 +117,6 @@ class SSOInfo(BaseModel):
 class SSO(BaseModel):
     enable_sso: bool
     protocols: List[SSOInfo]
+
+class UserDefaultDomain(BaseModel):
+    user_default_domain: str


### PR DESCRIPTION
Have added the changes for the OSPC-696 : Create a new configuration option for skyline that will allow the default domain to be set when defined.
Also tested it in my local by configuring the 'default_domain' parameter to 'Default' value in the configbin.yaml file.
And verified the scenario on noth Backend and Front End, Where it is succeefully fetched the parameter on front end from the Backend Configuration file using api end point, and passing in the login proceess to the backend, where as previously the default domain was hard coded.

There is one more test to be done on DFW-DEV env for domain name rackspace_cloud_domain, after we push this changes to master, and also will raise one PR for configbin.yaml under genestack repo to add parameter 'default_domain'. 
