### PR TITLE
Include tenant_id for neutron policy checking

### DIFF
--- a/skyline_apiserver/api/v1/policy.py
+++ b/skyline_apiserver/api/v1/policy.py
@@ -72,6 +72,8 @@ def _generate_target(profile: schemas.Profile) -> Dict[str, str]:
         "owner": profile.project.id,
         # cinder
         "domain_id": profile.project.domain.id,
+        # neutron
+        "tenant_id": profile.project.id,
     }
 
 


### PR DESCRIPTION
See https://bugs.launchpad.net/skyline-console/+bug/2115420: neutron-vpnaas uses tenant_id in the default policy rules but we do not supply that information in the policy endpoint.

Change-Id: I0c920a18d17eef42cc8506cc08e54f7d2f9a2e4c (cherry picked from commit 1772416d6c923c170e10f22d65b510fb36cd05c4)